### PR TITLE
Upgrade to hybrid polymer 1 and 2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "oak-ajax-behavior",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "authors": [
     "Anonymous <anonymous@example.com>"
   ],
@@ -18,10 +18,10 @@
     "/test/"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.2.0"
+    "polymer": "Polymer/polymer#1.9 - 2"
   },
   "devDependencies": {
-    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "web-component-tester": "^4.3.5"
+    "iron-component-page": "PolymerElements/iron-component-page#1 - 3",
+    "web-component-tester": "5 - 6"
   }
 }

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -22,25 +22,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <link rel="import" href="./x-el.html">
   </head>
   <body>
-    <test-fixture id='x-el'>
+    <test-fixture id='x-el-fixture'>
       <template>
         <x-el></x-el>
       </template>
     </test-fixture>
     <script>
-      suite('oak-ajax-behavior', function() {
+      describe('oak-ajax-behavior', function() {
         var el;
 
-        setup(function() {
-          el = fixture('x-el');
+        beforeEach(function() {
+          el = fixture('x-el-fixture');
         });
 
-        test('it should have a default `undefined` sessionId', function() {
+        it('it should have a default `undefined` sessionId', function() {
           assert.equal(el.sessionId, undefined);
           assert.equal(el.sessionId, OakAJAXBehavior.sessionId);
         });
 
-        test('it should properly set the sessionId when assigned', function() {
+        it('it should properly set the sessionId when assigned', function() {
           var val = 'asdf1234567890';
           var authObj = {
             'Content-Type':'application/json',
@@ -52,7 +52,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.deepEqual(el.authHeaders, authObj);
         });
 
-        test('it should properly assign ajaxBase to integration', function() {
+        it('it should properly assign ajaxBase to integration', function() {
           assert.equal(el.ajaxBase, computeUrl(location.origin));
         });
 


### PR DESCRIPTION
This is so that you can include it in a polymer 1.x or 2.x app without having to add a resolution. It also makes sure that it runs ok in polymer 2.